### PR TITLE
uri parse bug fixed

### DIFF
--- a/src/Slim/Middleware/HttpBasicAuth.php
+++ b/src/Slim/Middleware/HttpBasicAuth.php
@@ -32,7 +32,11 @@ class HttpBasicAuth extends \Slim\Middleware {
         $request = $this->app->request;
 
         /* If path matches what is given on initialization. */
-        if (false !== strpos($request->getPath(), $this->options["path"])) {
+        // TODO: @taelkim how can 'subdirectory' support  
+        // ex) ( /admin/functionA , /admin/functionB, /admin/functionC ) as (/admin/)
+        // excepts: /old/foo/bar/admin/freeFunctionA
+        // maybe likes ... ^/admin/*
+        if ($request->getPathInfo() == $this->options["path"]) {
             $user = $request->headers("PHP_AUTH_USER");
             $pass = $request->headers("PHP_AUTH_PW");
 
@@ -41,7 +45,7 @@ class HttpBasicAuth extends \Slim\Middleware {
                 $this->next->call();
             } else {
                 $this->app->response->status(401);
-                $this->app->response->header("WWW-Authenticate", sprintf('Basic realm="%s"', $this->options["realm"]));;
+                $this->app->response->header("WWW-Authenticate", sprintf('Basic realm="%s"', $this->options["realm"]));
                 return;
             }
         } else {


### PR DESCRIPTION
bug case:

uri : /status and /stat have same action!
because, "/stat'us'" matched by "/stat"

it changed to check exactly matching by '==' operator
