### PR TITLE
Set passthrough in RequestPathRule from configuration parameter

### DIFF
--- a/src/HttpBasicAuthentication.php
+++ b/src/HttpBasicAuthentication.php
@@ -31,6 +31,7 @@ class HttpBasicAuthentication
         "relaxed" => array("localhost", "127.0.0.1"),
         "users" => null,
         "path" => null,
+        "passthrough" => null,
         "realm" => "Protected",
         "environment" => "HTTP_AUTHORIZATION",
         "authenticator" => null,
@@ -60,11 +61,19 @@ class HttpBasicAuthentication
             )));
         }
 
-        /* If path was given in easy mode add rule for it. */
+        /* If path or passthrough was given in easy mode add rule for it. */
+        $pathRules = array();
+
         if (null !== ($this->options["path"])) {
-            $this->addRule(new RequestPathRule(array(
-                "path" => $this->options["path"]
-            )));
+            $pathRules["path"] = $this->options["path"];
+        }
+
+        if (null !== ($this->options["passthrough"])) {
+            $pathRules["passthrough"] = $this->options["passthrough"];
+        }
+
+        if (!empty($pathRules)) {
+            $this->addRule(new RequestPathRule($pathRules));
         }
 
         /* There must be an authenticator either passed via options */
@@ -216,6 +225,17 @@ class HttpBasicAuthentication
     private function setPath($path)
     {
         $this->options["path"] = $path;
+        return $this;
+    }
+
+    public function getPassthrough()
+    {
+        return $this->options["passthrough"];
+    }
+
+    private function setPassthrough($path)
+    {
+        $this->options["passthrough"] = $path;
         return $this;
     }
 

--- a/test/BasicAuthenticationTest.php
+++ b/test/BasicAuthenticationTest.php
@@ -37,6 +37,7 @@ class HttpBasicAuthenticationTest extends \PHPUnit_Framework_TestCase
     {
         $auth = new \Slim\Middleware\HttpBasicAuthentication(array(
             "path" => "/admin",
+            "passthrough" => "/hello",
             "realm" => "Mordor",
             "users" => array(
                 "root" => "t00r",
@@ -49,6 +50,7 @@ class HttpBasicAuthenticationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals("t00r", $users["root"]);
         $this->assertEquals("/admin", $auth->getPath());
+        $this->assertEquals("/hello", $auth->getPassthrough());
         $this->assertEquals("Mordor", $auth->getRealm());
         $this->assertEquals("HTTP_AUTHORIZATION", $auth->getEnvironment());
         $this->assertInstanceOf(


### PR DESCRIPTION
there's a passthrough variable in RequestPathRule.php, but no way of set it up from configuration parameter.

edit: should have been about RequestPathRule instead of RequestMethodRule
