### PR TITLE
add type declaration to after & error methods parameters

### DIFF
--- a/src/HttpBasicAuthentication.php
+++ b/src/HttpBasicAuthentication.php
@@ -285,7 +285,7 @@ class HttpBasicAuthentication
      * @param callable $after
      * @return void
      */
-    private function after($after)
+    private function after(callable $after)
     {
         $this->options["after"] = $after->bindTo($this);
     }
@@ -296,7 +296,7 @@ class HttpBasicAuthentication
      * @param callable $error
      * @return void
      */
-    private function error($error)
+    private function error(callable $error)
     {
         $this->options["error"] = $error;
     }


### PR DESCRIPTION
after() && error() methods accept one parameter which supposed to be a callback, we need here to add the type declaration.