### PR TITLE
Pass Request and Response to Authenticator

### DIFF
--- a/src/HttpBasicAuthentication.php
+++ b/src/HttpBasicAuthentication.php
@@ -119,7 +119,7 @@ class HttpBasicAuthentication
         $params = ["user" => $user, "password" => $password];
 
         /* Check if user authenticates. */
-        if (false === $this->options["authenticator"]($params)) {
+        if (false === $this->options["authenticator"]($params, $request, $response)) {
             /* Set response headers before giving it to error callback */
             $response = $response
                 ->withStatus(401)


### PR DESCRIPTION
Allowing the authenticator to have access to Request + Response allows for other Middleware to add in "Forbidden" before getting to HTTP Auth.
Use case - Tor / DDOS / IP prevention.

i.e.
    "authenticator" => function (
        $arguments,
        \Psr\Http\Message\ServerRequestInterface $request,
        \Psr\Http\Message\ResponseInterface $response
    ) use ($container) {
        if (in_array($response->getStatusCode(), [401, 403])) {
            return false;
        }