### PR TITLE
Fix error when authentication not well formated

### DIFF
--- a/src/HttpBasicAuthentication.php
+++ b/src/HttpBasicAuthentication.php
@@ -112,7 +112,10 @@ final class HttpBasicAuthentication implements MiddlewareInterface
         $params = ["user" => null, "password" => null];
 
         if (preg_match("/Basic\s+(.*)$/i", $request->getHeaderLine("Authorization"), $matches)) {
-            list($params["user"], $params["password"]) = explode(":", base64_decode($matches[1]), 2);
+            $explodedCredential = explode(":", base64_decode($matches[1]), 2);
+            if(count($explodedCredential) == 2) {
+                list($params["user"], $params["password"]) = $explodedCredential;
+            }
         }
 
         /* Check if user authenticates. */

--- a/src/HttpBasicAuthentication.php
+++ b/src/HttpBasicAuthentication.php
@@ -113,7 +113,7 @@ final class HttpBasicAuthentication implements MiddlewareInterface
 
         if (preg_match("/Basic\s+(.*)$/i", $request->getHeaderLine("Authorization"), $matches)) {
             $explodedCredential = explode(":", base64_decode($matches[1]), 2);
-            if(count($explodedCredential) == 2) {
+            if (count($explodedCredential) == 2) {
                 list($params["user"], $params["password"]) = $explodedCredential;
             }
         }


### PR DESCRIPTION
Fix error when authentication doesn't contains any ":"
like: `Authorisation: Basic plop`

Error stack from my unit test:

```
Slim Application Error:
Type: PHPUnit\Framework\Error\Notice
Code: 8
Message: Undefined offset: 1
File: /home/xxx/vendor/tuupola/slim-basic-auth/src/HttpBasicAuthentication.php
Line: 115
Trace: #0 /home/xxx/vendor/tuupola/slim-basic-auth/src/HttpBasicAuthentication.php(115): PHPUnit\Util\ErrorHandler::handleError(8, 'Undefined offse...', '/home/xxxxx/...', 115, Array)
#1 /home/xxx/vendor/tuupola/callable-handler/src/DoublePassTrait.php(30): Tuupola\Middleware\HttpBasicAuthentication->process(Object(Slim\Http\Request), Object(Tuupola\Middleware\CallableHandler))
#2 [internal function]: Tuupola\Middleware\HttpBasicAuthentication->__invoke(Object(Slim\Http\Request), Object(Slim\Http\Response), Object(Slim\App))
#3 /home/xxx/vendor/slim/slim/Slim/DeferredCallable.php(43): call_user_func_array(Object(Tuupola\Middleware\HttpBasicAuthentication), Array)
#4 [internal function]: Slim\DeferredCallable->__invoke(Object(Slim\Http\Request), Object(Slim\Http\Response), Object(Slim\App))
#5 /home/xxx/vendor/slim/slim/Slim/MiddlewareAwareTrait.php(70): call_user_func(Object(Slim\DeferredCallable), Object(Slim\Http\Request), Object(Slim\Http\Response), Object(Slim\App))
#6 /home/xxx/vendor/slim/slim/Slim/MiddlewareAwareTrait.php(117): Slim\App->Slim\{closure}(Object(Slim\Http\Request), Object(Slim\Http\Response))
#7 /home/xxx/vendor/slim/slim/Slim/App.php(388): Slim\App->callMiddlewareStack(Object(Slim\Http\Request), Object(Slim\Http\Response))
#8 /home/xxx/test/BaseTestCase.php(187): Slim\App->process(Object(Slim\Http\Request), Object(Slim\Http\Response))
#9 /home/xxx/test/routes/AuthTest.php(42): Trace\CommonAPI\Server\Test\BaseTestCase->executeSlimRoute('GET', '/', NULL, Array, false)
#10 [internal function]: Trace\CommonAPI\Server\Test\routes\AuthTest->testAuthWithInvalidCredential('Authorization', 'Basic cGxvcHBsY...')
#11 /home/xxx/vendor/phpunit/phpunit/src/Framework/TestCase.php(1071): ReflectionMethod->invokeArgs(Object(Trace\CommonAPI\Server\Test\routes\AuthTest), Array)
#12 /home/xxx/vendor/phpunit/phpunit/src/Framework/TestCase.php(939): PHPUnit\Framework\TestCase->runTest()
#13 /home/xxx/vendor/phpunit/phpunit/src/Framework/TestResult.php(698): PHPUnit\Framework\TestCase->runBare()
#14 /home/xxx/vendor/phpunit/phpunit/src/Framework/TestCase.php(894): PHPUnit\Framework\TestResult->run(Object(Trace\CommonAPI\Server\Test\routes\AuthTest))
#15 /home/xxx/vendor/phpunit/phpunit/src/Framework/TestSuite.php(755): PHPUnit\Framework\TestCase->run(Object(PHPUnit\Framework\TestResult))
#16 /home/xxx/vendor/phpunit/phpunit/src/Framework/TestSuite.php(755): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#17 /home/xxx/vendor/phpunit/phpunit/src/Framework/TestSuite.php(755): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#18 /home/xxx/vendor/phpunit/phpunit/src/Framework/TestSuite.php(755): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#19 /home/xxx/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(546): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#20 /home/xxx/vendor/phpunit/phpunit/src/TextUI/Command.php(195): PHPUnit\TextUI\TestRunner->doRun(Object(PHPUnit\Framework\TestSuite), Array, true)
#21 /home/xxx/vendor/phpunit/phpunit/src/TextUI/Command.php(148): PHPUnit\TextUI\Command->run(Array, true)
#22 /home/xxx/vendor/phpunit/phpunit/phpunit(53): PHPUnit\TextUI\Command::main()
#23 {main}
```
