### PR TITLE
Requested url should be http to verify that the config is working

### DIFF
--- a/tests/BasicAuthenticationTest.php
+++ b/tests/BasicAuthenticationTest.php
@@ -523,7 +523,7 @@ class HttpBasicAuthenticationTest extends TestCase
     public function testShouldRelaxInsecureViaSetting()
     {
         $request = (new ServerRequestFactory)
-            ->createServerRequest("GET", "https://example.com/api");
+            ->createServerRequest("GET", "http://example.com/api");
 
         $response = (new ResponseFactory)->createResponse();
 


### PR DESCRIPTION
If I've got it right, this is just a bug in the test.  If we request https, then we're not actually testing the 'relaxed' code path.
