### PR TITLE
Fix Authorization header

### DIFF
--- a/src/HttpBasicAuthentication.php
+++ b/src/HttpBasicAuthentication.php
@@ -123,10 +123,13 @@ final class HttpBasicAuthentication implements MiddlewareInterface
         /* Just in case. */
         $params = ["user" => null, "password" => null];
 
-        if (preg_match("/Basic\s+(.*)$/i", $request->getHeaderLine("Authorization"), $matches)) {
-            $explodedCredential = explode(":", base64_decode($matches[1]), 2);
-            if (count($explodedCredential) == 2) {
-                list($params["user"], $params["password"]) = $explodedCredential;
+        $authheader = explode(",", $request->getHeaderLine("Authorization"));
+        foreach ($authheader as $h) {
+            if (preg_match("/Basic\s+(.*)$/i", $h, $matches)) {
+                $explodedCredential = explode(":", base64_decode($matches[1]), 2);
+                if (count($explodedCredential) == 2) {
+                    list($params["user"], $params["password"]) = $explodedCredential;
+                }
             }
         }
 

--- a/tests/BasicAuthenticationTest.php
+++ b/tests/BasicAuthenticationTest.php
@@ -120,6 +120,35 @@ class HttpBasicAuthenticationTest extends TestCase
         $this->assertEquals("Success", $response->getBody());
     }
 
+    public function testShouldReturn200WithMultipleHeaders()
+    {
+        $request = (new ServerRequestFactory)
+            ->createServerRequest("GET", "https://example.com/admin/item")
+            ->withHeader("Authorization", "Basic cm9vdDp0MDBy,Basic cm9vdDp0MDBy");
+
+        $response = (new ResponseFactory)->createResponse();
+
+        $auth = new HttpBasicAuthentication([
+            "path" => "/admin",
+            "realm" => "Protected",
+            "users" => [
+                "root" => "t00r",
+                "user" => "passw0rd"
+            ]
+        ]);
+
+        $next = function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write("Success");
+            return $response;
+        };
+
+        $response = $auth($request, $response, $next);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals("Success", $response->getBody());
+    }
+
+
     public function testShouldReturn200WithOptions()
     {
         $request = (new ServerRequestFactory)


### PR DESCRIPTION
Fixes #89

Since getHeaderLine() can return a coma separated string, i add an explode and a foreach.

Updated tests to reflect the change