### PR TITLE
Remove https header check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+# [4.0.0](https://github.com/tuupola//slim-basic-auth/compare/3.2.1...4.x) - unreleased
+### Removed
+- Support for relaxing security setting via HTTPS proxy headers. Either set `secure` to `false` or use a separate middleware for setting request protocol according to headers ([#94](https://github.com/tuupola/branca-middleware/pull/94)).
+
+
 # [3.2.1](https://github.com/tuupola//slim-basic-auth/compare/3.2.0...3.2.1) - 2018-10-15
 ### Added
 - Support for tuupola/callable-handler:^1.0 and tuupola/http-factory:^1.0

--- a/README.md
+++ b/README.md
@@ -159,7 +159,9 @@ $app->add(new Tuupola\Middleware\HttpBasicAuthentication([
 
 ## Security
 
-Browsers send passwords over the wire basically as cleartext. You should always use HTTPS. If the middleware detects insecure usage over HTTP it will throw `RuntimeException`. This rule is relaxed for localhost. To allow insecure usage you must enable it manually by setting `secure` to `false`.
+Basic authentication transmits credentials in clear text. For this reason HTTPS should always be used together with basic authentication. If the middleware detects insecure usage over HTTP it will throw a `RuntimeException` with the following message: `Insecure use of middleware over HTTP denied by configuration`.
+
+By default this rule is relaxed for localhost. To always allow insecure usage you must enable it manually by setting `secure` to `false`.
 
 
 ``` php

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ $app->add(new Tuupola\Middleware\HttpBasicAuthentication([
         "root" => "t00r",
         "somebody" => "passw0rd"
     ],
-    "after" => function ($request, $response, $arguments) {
+    "after" => function ($response, $arguments) {
         return $response->withHeader("X-Brawndo", "plants crave");
     }
 ]));

--- a/src/HttpBasicAuthentication.php
+++ b/src/HttpBasicAuthentication.php
@@ -99,19 +99,7 @@ final class HttpBasicAuthentication implements MiddlewareInterface
 
         /* HTTP allowed only if secure is false or server is in relaxed array. */
         if ("https" !== $scheme && true === $this->options["secure"]) {
-            $allowedHost = in_array($host, $this->options["relaxed"]);
-
-            /* if 'headers' is in the 'relaxed' key, then we check for forwarding */
-            $allowedForward = false;
-            if (in_array("headers", $this->options["relaxed"])) {
-                if ($request->getHeaderLine("X-Forwarded-Proto") === "https"
-                    && $request->getHeaderLine('X-Forwarded-Port') === "443"
-                ) {
-                    $allowedForward = true;
-                }
-            }
-
-            if (!($allowedHost || $allowedForward)) {
+            if (!in_array($host, $this->options["relaxed"])) {
                 $message = sprintf(
                     "Insecure use of middleware over %s denied by configuration.",
                     strtoupper($scheme)

--- a/tests/BasicAuthenticationTest.php
+++ b/tests/BasicAuthenticationTest.php
@@ -547,35 +547,6 @@ class HttpBasicAuthenticationTest extends TestCase
         $this->assertEquals(401, $response->getStatusCode());
     }
 
-    public function testShouldRelaxForwardedViaSetting()
-    {
-        $request = (new ServerRequestFactory)
-            ->createServerRequest("GET", "http://example.com/api")
-            ->withHeader("X-Forwarded-Proto", "https")
-            ->withHeader("X-Forwarded-Port", "443");
-
-        $response = (new ResponseFactory)->createResponse();
-
-        $auth = new HttpBasicAuthentication([
-            "secure" => true,
-            "relaxed" => ["localhost", "headers"],
-            "path" => "/api",
-            "users" => [
-                "root" => "t00r",
-                "user" => "passw0rd"
-            ]
-        ]);
-
-        $next = function (ServerRequestInterface $request, ResponseInterface $response) {
-            $response->getBody()->write("Success");
-            return $response;
-        };
-
-        $response = $auth($request, $response, $next);
-
-        $this->assertEquals(401, $response->getStatusCode());
-    }
-
     public function testShouldBeImmutable()
     {
         $auth = new HttpBasicAuthentication([


### PR DESCRIPTION
This reverts commit c27776425c007d2c216899caaacda8d527f798ef. There is two reasons for reverting. 

1. There is no difference between setting `secure` to `false` and trusting an arbitrary header.
2. It is not this middlewares responsibility work around insecure HTTPS proxying.

As an alternative set `secure` to `false` or use a middleware which checks the `X-Forwarded-Proto` etc headers and sets the https method accordingly. It is still fake sense of security though.