### PR TITLE
Add given params to processError arguments

### DIFF
--- a/src/HttpBasicAuthentication.php
+++ b/src/HttpBasicAuthentication.php
@@ -175,6 +175,7 @@ final class HttpBasicAuthentication implements MiddlewareInterface
 
             return $this->processError($response, [
                 "message" => "Authentication failed",
+                "params" => $params,
             ]);
         }
 


### PR DESCRIPTION
Added entered params to processError arguments.

**Reason:**
To enable easy logging of wrong logins. Also makes it so much easier to enforce rate limit ect. in case of brute force attempts.